### PR TITLE
Address heapq issues on tuple(number, dict) in retrieval_and_answer.py (TypeError: '<' not supported between instances of 'dict' and 'dict'). 

### DIFF
--- a/eval/retrieval_and_answer.py
+++ b/eval/retrieval_and_answer.py
@@ -22,16 +22,16 @@ class RetrievalAndAnswer:
                     page, overall_score = page_info
                     # 使用最小堆来保持前queue_capacity个最高分项目
                     if len(top_pages_heap) < self.queue_capacity:
-                        heapq.heappush(top_pages_heap, (overall_score, page))
+                        heapq.heappush(top_pages_heap, (overall_score, id(page), page))
                     else:
                         # 如果当前分数高于堆中最小的分数，则替换
                         if overall_score > top_pages_heap[0][0]:
                             heapq.heappop(top_pages_heap)
-                            heapq.heappush(top_pages_heap, (overall_score, page))
+                            heapq.heappush(top_pages_heap, (overall_score, id(page), page))
             
             # 清空并重新填充检索队列，按分数从高到低排序
             self.retrieval_queue.clear()
-            for score, page in sorted(top_pages_heap, key=lambda x: x[0], reverse=True):
+            for score, _, page in sorted(top_pages_heap, key=lambda x: x[0], reverse=True):
                 self.retrieval_queue.append(page)
             
             print(f"检索：中期记忆召回 {len(self.retrieval_queue)} 个 QA 对到检索队列。")


### PR DESCRIPTION
In retrieval_and_answer.py, starting from line 25, when the overall_score of the newly added page is the same as some pages that have been inserted in the heap, it will raise the **TypeError: '<' not supported between instances of 'dict' and 'dict'**.

<img width="1308" height="326" alt="image" src="https://github.com/user-attachments/assets/f9fb5823-df0d-4b5b-94f8-65fd22411545" />

I have also created a simple testing program for your reference:
<img width="1344" height="902" alt="image" src="https://github.com/user-attachments/assets/421c1b21-2abb-4e62-ba2e-bd59fba503f9" />



This issue arises because heapq, _when the first elements of two tuples are identical, automatically proceeds to compare their second elements_. However, in the project, the constructed tuple is (overall_score, page), where page is a dict, and dictionaries are not comparable to one another (Can refer to some QA on stackoverflow about this issue, e.g., https://stackoverflow.com/questions/3954530/how-to-make-heapq-evaluate-the-heap-off-of-a-specific-attribute).

A convenient fix I pushed is to insert an id field as the second element, since ids are guaranteed to be unique. This extra field can then be easily ignored subsequently (e.g., on line 34 in retrieval_and_answer.py), which will not affect any subsequent operations.


 
