### PR TITLE
0302 gf get_memory_stats

### DIFF
--- a/memoryos-pypi/memoryos.py
+++ b/memoryos-pypi/memoryos.py
@@ -358,5 +358,33 @@ class Memoryos:
         self._trigger_profile_and_knowledge_update_if_needed()
         self.mid_term_heat_threshold = original_threshold # Restore original threshold
 
+    def get_memory_stats(self) -> dict:
+        """
+        Retrieve the current storage statistics of the memory system.
+        Provides read-only monitoring capabilities with minimal intrusion, allowing 
+        developers or clients to check the load status of different memory layers.
+        """
+        stats = {
+            "user_id": self.user_id,
+            "short_term_count": len(self.short_term_memory.get_all()),
+            "mid_term_sessions_count": len(self.mid_term_memory.sessions),
+        }
+        
+        # Safely attempt to retrieve long-term memory status to prevent execution failures
+        try:
+            # Verify the existence and validity of the user profile
+            profile = self.user_long_term_memory.get_raw_user_profile(self.user_id)
+            stats["has_user_profile"] = bool(profile and profile.lower() != "none" and "No detailed profile" not in profile)
+            
+            # Calculate the total number of assistant knowledge entries
+            assistant_knowledge = self.get_assistant_knowledge_summary()
+            stats["assistant_knowledge_count"] = len(assistant_knowledge) if isinstance(assistant_knowledge, list) else 0
+            
+        except Exception as e:
+            # Catch any unexpected schema or attribute errors gracefully
+            stats["long_term_stats_error"] = str(e)
+            
+        return stats
+
     def __repr__(self):
         return f"<Memoryos user_id='{self.user_id}' assistant_id='{self.assistant_id}' data_path='{self.data_storage_path}'>" 


### PR DESCRIPTION
This commit introduces a get_memory_stats method to the Memoryos class to provide a safe, read-only snapshot of the current memory load across all hierarchical storage layers.

Problem:
Developers and integrated clients (e.g., UI dashboards, MCP servers) currently lack a straightforward method to monitor the capacity and status of the short-term, mid-term, and long-term memory modules.
Without visibility into the memory system's internal state, it is difficult to track memory accumulation, debug context limits, or confirm when long-term profile updates are successfully triggered.
Solution:
Added a get_memory_stats() function to the main Memoryos orchestrator class.
The method safely aggregates record counts for short-term QA pairs, active mid-term sessions, and validates the presence of long-term user profiles and assistant knowledge.
Implemented strict error handling (try-except) around long-term memory checks to ensure absolute zero disruption to the core memory read/write pipeline.
Changes:
Modified memoryos-pypi/memoryos.py