### PR TITLE
修复短期记忆满容时的静默数据丢失问题

### DIFF
--- a/memoryos-chromadb/memoryos.py
+++ b/memoryos-chromadb/memoryos.py
@@ -247,12 +247,14 @@ class Memoryos:
             "agent_response": agent_response,
             "timestamp": timestamp
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-mcp/memoryos/memoryos.py
+++ b/memoryos-mcp/memoryos/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-playground/memoryos.py
+++ b/memoryos-playground/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-pypi/memoryos.py
+++ b/memoryos-pypi/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()


### PR DESCRIPTION
在 `add_memory()` 方法中，旧的执行顺序是：
  1. 先将新的 QA pair append 到固定容量的 deque
  2. 再检查 `is_full()` 并触发向中期记忆的迁移

  由于 `deque(maxlen=N)` 在满容时会静默丢弃最左侧元素，这导致每次短期记忆溢出周期中，至少有一条 QA 对被永久丢失，从未进入中期记忆或长期记忆。

修复方案:

  调整执行顺序：
  1. 先调用 `process_short_term_to_mid_term()` 将旧数据安全迁移到中期记忆
  2. 再append 新的 QA pair

  这样确保没有任何数据在 deque 的自动驱逐过程中被静默丢弃。

 影响范围

  该修复已同步应用到所有四个发行版本：
  - `memoryos-pypi/memoryos.py`
  - `memoryos-playground/memoryos.py`
  - `memoryos-chromadb/memoryos.py`
  - `memoryos-mcp/memoryos/memoryos.py`

测试

  运行 `memoryos-pypi/test.py` 验证，10 条测试对话全部正确迁移到中期记忆，查询时能够正常召回相关内容。