### PR TITLE
增加用户画像更新前的内容质量校验

### DIFF
--- a/memoryos-chromadb/memoryos.py
+++ b/memoryos-chromadb/memoryos.py
@@ -247,12 +247,14 @@ class Memoryos:
             "agent_response": agent_response,
             "timestamp": timestamp
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-mcp/memoryos/memoryos.py
+++ b/memoryos-mcp/memoryos/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-mcp/memoryos/memoryos.py
+++ b/memoryos-mcp/memoryos/memoryos.py
@@ -183,9 +183,13 @@ class Memoryos:
                 new_assistant_knowledge = knowledge_result.get("assistant_knowledge")
 
                 # 直接使用更新后的完整用户画像
-                if updated_user_profile and updated_user_profile.lower() != "none":
+                if (updated_user_profile and
+                        updated_user_profile.lower() != "none" and
+                        len(updated_user_profile.strip()) >= 30):
                     print("Memoryos: Updating user profile with integrated analysis...")
                     self.user_long_term_memory.update_user_profile(self.user_id, updated_user_profile, merge=False)  # 直接替换为新的完整画像
+                else:
+                    print("Memoryos: Skipping user profile update due to insufficient content.")
                 
                 # Add User Private Knowledge to user's LTM
                 if new_user_private_knowledge and new_user_private_knowledge.lower() != "none":

--- a/memoryos-playground/memoryos.py
+++ b/memoryos-playground/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-playground/memoryos.py
+++ b/memoryos-playground/memoryos.py
@@ -183,9 +183,13 @@ class Memoryos:
                 new_assistant_knowledge = knowledge_result.get("assistant_knowledge")
 
                 # 直接使用更新后的完整用户画像
-                if updated_user_profile and updated_user_profile.lower() != "none":
+                if (updated_user_profile and
+                        updated_user_profile.lower() != "none" and
+                        len(updated_user_profile.strip()) >= 30):
                     print("Memoryos: Updating user profile with integrated analysis...")
                     self.user_long_term_memory.update_user_profile(self.user_id, updated_user_profile, merge=False)  # 直接替换为新的完整画像
+                else:
+                    print("Memoryos: Skipping user profile update due to insufficient content.")
                 
                 # Add User Private Knowledge to user's LTM
                 if new_user_private_knowledge and new_user_private_knowledge.lower() != "none":

--- a/memoryos-pypi/memoryos.py
+++ b/memoryos-pypi/memoryos.py
@@ -233,12 +233,14 @@ class Memoryos:
             "timestamp": timestamp
             # meta_data can be added here if it needs to be stored with the QA pair
         }
-        self.short_term_memory.add_qa_pair(qa_pair)
-        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
-
+        # FIX: Migrate old entries BEFORE adding the new one to prevent
+        # silent data loss from deque auto-eviction.
         if self.short_term_memory.is_full():
             print("Memoryos: Short-term memory full. Processing to mid-term.")
             self.updater.process_short_term_to_mid_term()
+
+        self.short_term_memory.add_qa_pair(qa_pair)
+        print(f"Memoryos: Added QA to short-term. User: {user_input[:30]}...")
         
         # After any memory addition that might impact mid-term, check for profile updates
         self._trigger_profile_and_knowledge_update_if_needed()

--- a/memoryos-pypi/memoryos.py
+++ b/memoryos-pypi/memoryos.py
@@ -183,9 +183,13 @@ class Memoryos:
                 new_assistant_knowledge = knowledge_result.get("assistant_knowledge")
 
                 # 直接使用更新后的完整用户画像
-                if updated_user_profile and updated_user_profile.lower() != "none":
+                if (updated_user_profile and
+                        updated_user_profile.lower() != "none" and
+                        len(updated_user_profile.strip()) >= 30):
                     print("Memoryos: Updating user profile with integrated analysis...")
                     self.user_long_term_memory.update_user_profile(self.user_id, updated_user_profile, merge=False)  # 直接替换为新的完整画像
+                else:
+                    print("Memoryos: Skipping user profile update due to insufficient content.")
                 
                 # Add User Private Knowledge to user's LTM
                 if new_user_private_knowledge and new_user_private_knowledge.lower() != "none":


### PR DESCRIPTION
问题描述

  在 `_trigger_profile_and_knowledge_update_if_needed()` 中，当 LLM 分析用户画像后，只要返回值不为空且不是 `"None"`，就会直接用 `merge=False` 覆盖已有的长期画像。

  这存在风险：如果 LLM 返回了过短、无意义的内容（如 `"No data."`、`"Unknown."`、甚至空字符串），已有的、经过多轮积累的用户画像会被**直接清空**。

修复方案

  在覆盖画像前增加一个**最小长度校验**（`>= 30` 字符），过滤掉低质量的 LLM 响应：
  ```python
  if (updated_user_profile and
          updated_user_profile.lower() != "none" and
          len(updated_user_profile.strip()) >= 30):
      # 执行更新
  else:
      # 跳过本次更新，保留已有画像

  这样即使 LLM 偶尔返回异常内容，也不会破坏已经积累的用户画像。

  影响范围

  - memoryos-pypi/memoryos.py
  - memoryos-playground/memoryos.py
  - memoryos-mcp/memoryos/memoryos.py

