### PR TITLE
Remove hardcoded API key from playground/test.py (CWE-798)

### DIFF
--- a/memoryos-playground/test.py
+++ b/memoryos-playground/test.py
@@ -5,7 +5,7 @@ from memoryos import Memoryos
 # --- Basic Configuration ---
 USER_ID = "demo_user"
 ASSISTANT_ID = "demo_assistant"
-API_KEY = "sk-7VaFJuGM146a957c4E75T3BlBkFJb7232107783F41C29e00"  # Replace with your key
+API_KEY = ""  # Replace with your key
 BASE_URL = "https://cn2us02.opapi.win/v1"  # Optional: if using a custom OpenAI endpoint
 DATA_STORAGE_PATH = "./simple_demo_data"
 LLM_MODEL = "gpt-4o-mini"


### PR DESCRIPTION
## Summary

`memoryos-playground/test.py` contains a hardcoded API key for the OpenAI-compatible proxy at `cn2us02.opapi.win`. Because this repository is public, the key is exposed to anyone who clones, forks, or browses the repo — including automated secret-scanning bots, which typically discover and abuse such keys within minutes of being committed.

- **CWE:** [CWE-798: Use of Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)
- **File:** `memoryos-playground/test.py`, line 8
- **Severity:** High (financial exposure — the leaked key is for a paid LLM proxy)

## The vulnerability

```python
API_KEY = "sk-7VaFJuGM146a957c4E75T3BlBkFJb7232107783F41C29e00"  # Replace with your key
BASE_URL = "https://cn2us02.opapi.win/v1"
```

The literal `sk-...` value is a real-looking credential committed in plaintext. Any visitor to the public repo can copy it and issue requests against the configured proxy on the project owner's behalf, incurring usage costs and potentially exhausting quota for legitimate use.

## The fix

Replace the hardcoded literal with an empty string while keeping the existing `# Replace with your key` comment so the example still reads naturally:

```python
API_KEY = ""  # Replace with your key
```

The diff is two lines (the second hunk is just a trailing-newline normalization). No behavior change for users who were already expected to supply their own key.

## Testing

- `python -m py_compile memoryos-playground/test.py` — passes.
- The script is a demo/playground example. With an empty `API_KEY`, the OpenAI client will raise an authentication error at call time, which matches the existing "Replace with your key" expectation. Users who follow the comment and paste in their own key will get identical behavior to before.

## Security analysis

The exposure has no preconditions beyond "the repo is public." Automated GitHub key scanners routinely find and exploit keys matching the `sk-` prefix pattern, so the practical exploitability is essentially immediate. Removing the literal from `HEAD` stops the bleeding for new clones, forks, and code-search hits.

**Important operational note for maintainers:** the key remains in git history (it was introduced in an earlier commit). To fully mitigate, please **rotate / revoke the key at the proxy provider** in addition to merging this PR. History rewrite is optional but the rotation is essential — a code-only change cannot remove the secret from prior commits.

## Adversarial review

Before submitting, we tried to disprove this finding: we considered whether the key might be a deliberately-published demo credential, a test fixture for a sandbox endpoint, or already-revoked. None of those hold up — the file is a real usage example pointing at a paid third-party proxy (`opapi.win`), there is no README note marking the key as shared/demo, and the comment `# Replace with your key` makes clear the author considered it a placeholder rather than a public sample. Whether the key is currently live or already abused doesn't change the correctness of removing it from source.

cc @lewiswigmore
