### PR TITLE
修复记忆读写流程中的多个缺陷

### DIFF
--- a/memoryos-pypi/memoryos.py
+++ b/memoryos-pypi/memoryos.py
@@ -125,103 +125,117 @@ class Memoryos:
 
     def _trigger_profile_and_knowledge_update_if_needed(self):
         """
-        Checks mid-term memory for hot segments and triggers profile/knowledge update if threshold is met.
-        Adapted from main_memoybank.py's update_user_profile_from_top_segment.
-        Enhanced with parallel LLM processing for better performance.
+        Checks mid-term memory for hot segments and triggers profile/knowledge
+        update if threshold is met.  Processes ALL sessions above the threshold
+        (not just the single hottest), so that a burst of activity on multiple
+        topics does not leave any session indefinitely waiting for analysis.
         """
         if not self.mid_term_memory.heap:
             return
 
-        # Peek at the top of the heap (hottest segment)
-        # MidTermMemory heap stores (-H_segment, sid)
-        neg_heat, sid = self.mid_term_memory.heap[0] 
-        current_heat = -neg_heat
+        processed_any = False
 
-        if current_heat >= self.mid_term_heat_threshold:
+        # Loop while the hottest session is above threshold, so that every
+        # session that has crossed the line gets analysed in one pass.
+        while self.mid_term_memory.heap:
+            neg_heat, sid = self.mid_term_memory.heap[0]
+            current_heat = -neg_heat
+
+            if current_heat < self.mid_term_heat_threshold:
+                break  # nothing else is hot enough
+
             session = self.mid_term_memory.sessions.get(sid)
             if not session:
-                self.mid_term_memory.rebuild_heap() # Clean up if session is gone
-                return
+                self.mid_term_memory.rebuild_heap()
+                continue  # stale heap entry – rebuild and re-check
 
-            # Get unanalyzed pages from this hot session
-            # A page is a dict: {"user_input": ..., "agent_response": ..., "timestamp": ..., "analyzed": False, ...}
-            unanalyzed_pages = [p for p in session.get("details", []) if not p.get("analyzed", False)]
+            unanalyzed_pages = [p for p in session.get("details", [])
+                                if not p.get("analyzed", False)]
 
-            if unanalyzed_pages:
-                print(f"Memoryos: Mid-term session {sid} heat ({current_heat:.2f}) exceeded threshold. Analyzing {len(unanalyzed_pages)} pages for profile/knowledge update.")
-                
-                # 并行执行两个LLM任务：用户画像分析（已包含更新）、知识提取
-                def task_user_profile_analysis():
-                    print("Memoryos: Starting parallel user profile analysis and update...")
-                    # 获取现有用户画像
-                    existing_profile = self.user_long_term_memory.get_raw_user_profile(self.user_id)
-                    if not existing_profile or existing_profile.lower() == "none":
-                        existing_profile = "No existing profile data."
-                    
-                    # 直接输出更新后的完整画像
-                    return gpt_user_profile_analysis(unanalyzed_pages, self.client, model=self.llm_model, existing_user_profile=existing_profile)
-                
-                def task_knowledge_extraction():
-                    print("Memoryos: Starting parallel knowledge extraction...")
-                    return gpt_knowledge_extraction(unanalyzed_pages, self.client, model=self.llm_model)
-                
-                # 使用并行任务执行                
-                with ThreadPoolExecutor(max_workers=2) as executor:
-                    # 提交两个主要任务
-                    future_profile = executor.submit(task_user_profile_analysis)
-                    future_knowledge = executor.submit(task_knowledge_extraction)
-                    
-                    # 等待结果
-                    try:
-                        updated_user_profile = future_profile.result()  # 直接是更新后的完整画像
-                        knowledge_result = future_knowledge.result()
-                    except Exception as e:
-                        print(f"Error in parallel LLM processing: {e}")
-                        return
-                
-                new_user_private_knowledge = knowledge_result.get("private")
-                new_assistant_knowledge = knowledge_result.get("assistant_knowledge")
+            if not unanalyzed_pages:
+                # Session is hot but everything was already analysed.
+                # Reset its heat contributors so it does not keep occupying
+                # the top of the heap on every subsequent call.
+                print(f"Memoryos: Hot session {sid} has no unanalyzed pages. "
+                      f"Resetting heat to allow other sessions to surface.")
+                session["N_visit"] = 0
+                session["H_segment"] = compute_segment_heat(session)
+                self.mid_term_memory.rebuild_heap()
+                processed_any = True
+                continue
 
-                # 直接使用更新后的完整用户画像
-                if (updated_user_profile and
-                        updated_user_profile.lower() != "none" and
-                        len(updated_user_profile.strip()) >= 30):
-                    print("Memoryos: Updating user profile with integrated analysis...")
-                    self.user_long_term_memory.update_user_profile(self.user_id, updated_user_profile, merge=False)  # 直接替换为新的完整画像
-                else:
-                    print("Memoryos: Skipping user profile update due to insufficient content.")
-                
-                # Add User Private Knowledge to user's LTM
-                if new_user_private_knowledge and new_user_private_knowledge.lower() != "none":
-                    for line in new_user_private_knowledge.split('\n'):
-                         if line.strip() and line.strip().lower() not in ["none", "- none", "- none."]:
-                            self.user_long_term_memory.add_user_knowledge(line.strip())
+            print(f"Memoryos: Mid-term session {sid} heat ({current_heat:.2f}) "
+                  f"exceeded threshold. Analyzing {len(unanalyzed_pages)} pages "
+                  f"for profile/knowledge update.")
 
-                # Add Assistant Knowledge to assistant's LTM
-                if new_assistant_knowledge and new_assistant_knowledge.lower() != "none":
-                    for line in new_assistant_knowledge.split('\n'):
-                        if line.strip() and line.strip().lower() not in ["none", "- none", "- none."]:
-                           self.assistant_long_term_memory.add_assistant_knowledge(line.strip()) # Save to dedicated assistant LTM
+            # 并行执行两个LLM任务：用户画像分析（已包含更新）、知识提取
+            def task_user_profile_analysis():
+                print("Memoryos: Starting parallel user profile analysis and update...")
+                existing_profile = self.user_long_term_memory.get_raw_user_profile(self.user_id)
+                if not existing_profile or existing_profile.lower() == "none":
+                    existing_profile = "No existing profile data."
+                return gpt_user_profile_analysis(unanalyzed_pages, self.client,
+                                                  model=self.llm_model,
+                                                  existing_user_profile=existing_profile)
 
-                # Mark pages as analyzed and reset session heat contributors
-                for p in session["details"]:
-                    p["analyzed"] = True # Mark all pages in session, or just unanalyzed_pages?
-                                          # Original code marked all pages in session
-                
-                session["N_visit"] = 0 # Reset visits after analysis
-                session["L_interaction"] = 0 # Reset interaction length contribution
-                # session["R_recency"] = 1.0 # Recency will re-calculate naturally
-                session["H_segment"] = compute_segment_heat(session) # Recompute heat with reset factors
-                session["last_visit_time"] = get_timestamp() # Update last visit time
-                
-                self.mid_term_memory.rebuild_heap() # Heap needs rebuild due to H_segment change
-                self.mid_term_memory.save()
-                print(f"Memoryos: Profile/Knowledge update for session {sid} complete. Heat reset.")
+            def task_knowledge_extraction():
+                print("Memoryos: Starting parallel knowledge extraction...")
+                return gpt_knowledge_extraction(unanalyzed_pages, self.client,
+                                                 model=self.llm_model)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                future_profile = executor.submit(task_user_profile_analysis)
+                future_knowledge = executor.submit(task_knowledge_extraction)
+
+                try:
+                    updated_user_profile = future_profile.result()
+                    knowledge_result = future_knowledge.result()
+                except Exception as e:
+                    print(f"Error in parallel LLM processing: {e}")
+                    break  # do not process further sessions on error
+
+            new_user_private_knowledge = knowledge_result.get("private")
+            new_assistant_knowledge = knowledge_result.get("assistant_knowledge")
+
+            # 直接使用更新后的完整用户画像
+            if (updated_user_profile
+                    and updated_user_profile.lower() != "none"
+                    and len(updated_user_profile.strip()) >= 30):
+                print("Memoryos: Updating user profile with integrated analysis...")
+                self.user_long_term_memory.update_user_profile(
+                    self.user_id, updated_user_profile, merge=False)
             else:
-                print(f"Memoryos: Hot session {sid} has no unanalyzed pages. Skipping profile update.")
-        else:
-            # print(f"Memoryos: Top session {sid} heat ({current_heat:.2f}) below threshold. No profile update.")
-            pass # No action if below threshold
+                print("Memoryos: Skipping user profile update due to "
+                      "insufficient content.")
+
+            # Add User Private Knowledge to user's LTM
+            if new_user_private_knowledge and new_user_private_knowledge.lower() != "none":
+                for line in new_user_private_knowledge.split('\n'):
+                    if line.strip() and line.strip().lower() not in ["none", "- none", "- none."]:
+                        self.user_long_term_memory.add_user_knowledge(line.strip())
+
+            # Add Assistant Knowledge to assistant's LTM
+            if new_assistant_knowledge and new_assistant_knowledge.lower() != "none":
+                for line in new_assistant_knowledge.split('\n'):
+                    if line.strip() and line.strip().lower() not in ["none", "- none", "- none."]:
+                        self.assistant_long_term_memory.add_assistant_knowledge(line.strip())
+
+            # Mark pages as analyzed and reset session heat contributors
+            for p in session["details"]:
+                p["analyzed"] = True
+
+            session["N_visit"] = 0
+            session["L_interaction"] = 0
+            session["H_segment"] = compute_segment_heat(session)
+            session["last_visit_time"] = get_timestamp()
+
+            self.mid_term_memory.rebuild_heap()
+            processed_any = True
+            print(f"Memoryos: Profile/Knowledge update for session {sid} "
+                  f"complete. Heat reset.")
+
+        if processed_any:
+            self.mid_term_memory.save()
 
     def add_memory(self, user_input: str, agent_response: str, timestamp: str = None, meta_data: dict = None):
         """

--- a/memoryos-pypi/mid_term.py
+++ b/memoryos-pypi/mid_term.py
@@ -278,8 +278,8 @@ class MidTermMemory:
             print(f"MidTermMemory: No suitable session to merge (best score {best_overall_score:.2f} < threshold {similarity_threshold}). Creating new session.")
             return self.add_session(summary_for_new_pages, pages_to_insert, keywords_for_new_pages)
 
-    def search_sessions(self, query_text, segment_similarity_threshold=0.1, page_similarity_threshold=0.1, 
-                          top_k_sessions=5, keyword_alpha=1.0, recency_tau_search=3600):
+    def search_sessions(self, query_text, segment_similarity_threshold=0.1, page_similarity_threshold=0.1,
+                          top_k_sessions=5):
         if not self.sessions:
             return []
 
@@ -289,9 +289,7 @@ class MidTermMemory:
             **self.embedding_model_kwargs
         )
         query_vec = normalize_vector(query_vec)
-        query_keywords = set()  # Keywords extraction removed, relying on semantic similarity
 
-        candidate_sessions = []
         session_ids = list(self.sessions.keys())
         if not session_ids: return []
 
@@ -301,7 +299,7 @@ class MidTermMemory:
         dim = summary_embeddings_np.shape[1]
         index = faiss.IndexFlatIP(dim) # Inner product for similarity
         index.add(summary_embeddings_np)
-        
+
         query_arr_np = np.array([query_vec], dtype=np.float32)
         distances, indices = index.search(query_arr_np, min(top_k_sessions, len(session_ids)))
 
@@ -310,33 +308,20 @@ class MidTermMemory:
 
         for i, idx in enumerate(indices[0]):
             if idx == -1: continue
-            
+
             session_id = session_ids[idx]
             session = self.sessions[session_id]
             semantic_sim_score = float(distances[0][i]) # This is the dot product
 
-            # Keyword similarity for session summary
-            session_keywords = set(session.get("summary_keywords", []))
-            s_topic_keywords = 0
-            if query_keywords and session_keywords:
-                intersection = len(query_keywords.intersection(session_keywords))
-                union = len(query_keywords.union(session_keywords))
-                if union > 0: s_topic_keywords = intersection / union
-            
-            # Time decay for session recency in search scoring
-            # time_decay_factor = compute_time_decay(session["timestamp"], current_time_str, tau_hours=recency_tau_search)
-            
-            # Combined score for session relevance
-            session_relevance_score =  (semantic_sim_score + keyword_alpha * s_topic_keywords)
+            # Session relevance is based purely on semantic similarity (dot product of
+            # normalized summary embeddings = cosine similarity).
+            session_relevance_score = semantic_sim_score
 
             if session_relevance_score >= segment_similarity_threshold:
                 matched_pages_in_session = []
                 for page in session.get("details", []):
                     page_embedding = np.array(page["page_embedding"], dtype=np.float32)
-                    # page_keywords = set(page.get("page_keywords", []))
-                    
                     page_sim_score = float(np.dot(page_embedding, query_vec))
-                    # Can also add keyword sim for pages if needed, but keeping it simpler for now
 
                     if page_sim_score >= page_similarity_threshold:
                         matched_pages_in_session.append({"page_data": page, "score": page_sim_score})

--- a/memoryos-pypi/prompts.py
+++ b/memoryos-pypi/prompts.py
@@ -6,7 +6,7 @@ This file stores all the prompts used by the Memoryos system.
 GENERATE_SYSTEM_RESPONSE_SYSTEM_PROMPT = (
     "As a communication expert with outstanding communication habits, you embody the role of {relationship} throughout the following dialogues.\n"
     "Here are some of your distinctive personal traits and knowledge:\n{assistant_knowledge_text}\n"
-    "User's profile:\n"
+    "Current conversation metadata:\n"
     "{meta_data_text}\n"
     "Your task is to generate responses that align with these traits and maintain the tone.\n"
 )

--- a/memoryos-pypi/updater.py
+++ b/memoryos-pypi/updater.py
@@ -105,7 +105,9 @@ class Updater:
                 evicted_qas.append(qa)
         
         if not evicted_qas:
-            print("Updater: No QAs evicted from short-term memory.")
+            print("Updater: No valid QAs evicted from short-term memory. "
+                  "Resetting cross-batch continuity tracker to prevent stale linking.")
+            self.last_evicted_page_for_continuity = None
             return
 
         print(f"Updater: Processing {len(evicted_qas)} QAs from short-term to mid-term.")


### PR DESCRIPTION
  ## Summary                                                                                                                                             
  - 修复空QA批次导致跨批次连续性引用过期，防止页面被错误链接                                                                                             
  - 清理 `search_sessions` 中永久为空的关键词相似度死代码，简化检索评分                                                                                  
  - 修复热度触发仅处理单个 session 的问题，改为循环处理所有达到阈值的 session                                                                            
  - 修复热 session 无未分析页面时持续占据堆顶不释放的问题                                                                                                
  - 合并多次 `save()` 调用为循环结束后单次保存，减少冗余 I/O                                                                                             
  - 修正 System Prompt 中将 conversation metadata 误标为 "User's profile" 的命名混淆                                                                     
                                                                                                                                                         
  ## Details                                                                                                                                             
                                                                                                                                                         
  ### 1. 连续性引用过期 (`updater.py`)                                                                                                                   
  `process_short_term_to_mid_term` 中，当所有 evicted QAs 因内容为空被过滤后，方法 early return 但没有更新                                               
  `last_evicted_page_for_continuity`。下一次批量驱逐时可能将新页面错误链接到很久以前的过期页面。                                                         
                                                                                                                                                         
  修复：在 early return 前将引用重置为 `None`。                                                                                                          
                                                                                                                                                         
  ### 2. 检索死代码 (`mid_term.py`)                                                                                                                      
  `search_sessions` 中 `query_keywords = set()` 被写死为空集合，导致关键词 Jaccard 相似度计算永远返回 0，`keyword_alpha` 和 `recency_tau_search`         
  参数完全无效。                                                                                                                                         
                                                                                                                                                         
  修复：移除死代码和未使用参数，会话相关性直接使用语义相似度（归一化 embedding 内积 = 余弦相似度）。                                                     
                                                                                                                                                         
  ### 3. 单 session 热度处理 (`memoryos.py`)                                                                                                             
  `_trigger_profile_and_knowledge_update_if_needed` 使用 `if` 只检查堆顶 session，多个 session 同时超过热度阈值时其余被忽略。                            
                                                                                                                                                         
  修复：改为 `while` 循环，逐个处理所有达到阈值的 session，直到堆顶低于阈值。                                                                            
                                                                                                                                                         
  ### 4. 热 session 堆顶阻塞 (`memoryos.py`)                                                                                                             
  当热 session 所有页面已分析（`analyzed=True`）时，不重置热度，导致每次 `add_memory` 都 peek 到同一个 session 又跳过，浪费堆顶且阻塞其他 session。      
                                                                                                                                                         
  修复：无未分析页面时重置 `N_visit` 和 `H_segment`，释放堆顶给其他 session。                                                                            
                                                                                                                                                         
  ### 5. Prompt 命名混淆 (`prompts.py`)                                                                                                                  
  System prompt 中 `{meta_data_text}` 被标注为 "User's profile"，但实际传入的是 `user_conversation_meta_data`（对话元数据），真正的用户画像在 User prompt
   的 `background_context` 中。                                                                                                                          
                                                                                                                                                         
  修复：标签从 "User's profile" 更正为 "Current conversation metadata"。                                                                                 
                                                                                                                                                         
  ## Files Changed                                                                                                                                       
  | 文件 | 变更 |                                                                                                                                        
  |------|------|                                                                                                                                        
  | `updater.py` | +3/-1 重置过期连续性引用 |                                                                                                            
  | `mid_term.py` | +11/-26 清理检索死代码 |                                                                                                             
  | `memoryos.py` | +99/-87 循环处理多session + 合并save |                                                                                               
  | `prompts.py` | +1/-1 修正命名混淆 |                                                                                                                  
                                                                                                                                                         
  ## Test plan                                                                                                                                           
  - [x] 所有修改文件语法检查通过                                                                                                                         
  - [x] 确认无外部调用者依赖被删除的参数                                                                                                                 
  - [ ] 验证空 QA 驱逐后跨批次连续性正确断开                                                                                                             
  - [ ] 验证多 session 超阈值时全部被处理                                                                                                                
  - [ ] 验证检索结果不因死代码移除而变化                                                                                                                 
                                                                                                                                                         
  🤖 Generated with [Claude Code](https://claude.com/claude-code)